### PR TITLE
fix(annual-daylight): Refactor recipe to auto-split grids by cpu-count

### DIFF
--- a/lbt_recipes/annual_daylight/flow/main.py
+++ b/lbt_recipes/annual_daylight/flow/main.py
@@ -16,16 +16,17 @@ import luigi
 import os
 import pathlib
 from queenbee_local import QueenbeeTask
-from .dependencies.annual_daylight_ray_tracing import _AnnualDaylightRayTracing_4fe81c3cOrchestrator as AnnualDaylightRayTracing_4fe81c3cWorkerbee
+from .dependencies.annual_daylight_ray_tracing import _AnnualDaylightRayTracing_877ed6d8Orchestrator as AnnualDaylightRayTracing_877ed6d8Workerbee
 
 
-_default_inputs = {   'grid_filter': '*',
+_default_inputs = {   'cpu_count': 50,
+    'grid_filter': '*',
+    'min_sensor_count': 1,
     'model': None,
     'north': 0.0,
     'params_folder': '__params',
     'radiance_parameters': '-ab 2 -ad 5000 -lw 2e-05',
     'schedule': None,
-    'sensor_count': 200,
     'simulation_folder': '.',
     'thresholds': '-t 300 -lt 100 -ut 3000',
     'wea': None}
@@ -39,16 +40,16 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
 
     # Task inputs
     @property
-    def sensor_count(self):
-        return self._input_params['sensor_count']
-
-    @property
     def radiance_parameters(self):
         return self._input_params['radiance_parameters']
 
     @property
     def grid_name(self):
         return self.item['full_id']
+
+    @property
+    def sensor_count(self):
+        return self.item['count']
 
     @property
     def octree_file_with_suns(self):
@@ -64,7 +65,7 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
 
     @property
     def sensor_grid(self):
-        value = pathlib.Path(self.input()['CreateRadFolder']['model_folder'].path, 'grid/{item_full_id}.pts'.format(item_full_id=self.item['full_id']))
+        value = pathlib.Path(self.input()['SplitGridFolder']['output_folder'].path, '{item_full_id}.pts'.format(item_full_id=self.item['full_id']))
         return value.as_posix() if value.is_absolute() \
             else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
 
@@ -117,7 +118,7 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
 
     @property
     def execution_folder(self):
-        return pathlib.Path(self._input_params['simulation_folder'], 'initial_results/{item_name}'.format(item_name=self.item['name'])).resolve().as_posix()
+        return pathlib.Path(self._input_params['simulation_folder'], 'initial_results/{item_full_id}'.format(item_full_id=self.item['full_id'])).resolve().as_posix()
 
     @property
     def initiation_folder(self):
@@ -132,12 +133,12 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
         """Map task inputs to DAG inputs."""
         inputs = {
             'simulation_folder': self.execution_folder,
-            'sensor_count': self.sensor_count,
             'radiance_parameters': self.radiance_parameters,
             'octree_file_with_suns': self.octree_file_with_suns,
             'octree_file': self.octree_file,
             'grid_name': self.grid_name,
             'sensor_grid': self.sensor_grid,
+            'sensor_count': self.sensor_count,
             'sky_matrix': self.sky_matrix,
             'sky_dome': self.sky_dome,
             'sky_matrix_direct': self.sky_matrix_direct,
@@ -154,13 +155,13 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
         return inputs
 
     def run(self):
-        yield [AnnualDaylightRayTracing_4fe81c3cWorkerbee(_input_params=self.map_dag_inputs)]
+        yield [AnnualDaylightRayTracing_877ed6d8Workerbee(_input_params=self.map_dag_inputs)]
         done_file = pathlib.Path(self.execution_folder, 'annual_daylight_raytracing.done')
         done_file.parent.mkdir(parents=True, exist_ok=True)
         done_file.write_text('done!')
 
     def requires(self):
-        return {'CreateSkyDome': CreateSkyDome(_input_params=self._input_params), 'CreateOctreeWithSuns': CreateOctreeWithSuns(_input_params=self._input_params), 'CreateOctree': CreateOctree(_input_params=self._input_params), 'GenerateSunpath': GenerateSunpath(_input_params=self._input_params), 'CreateTotalSky': CreateTotalSky(_input_params=self._input_params), 'CreateDirectSky': CreateDirectSky(_input_params=self._input_params), 'CreateRadFolder': CreateRadFolder(_input_params=self._input_params)}
+        return {'CreateSkyDome': CreateSkyDome(_input_params=self._input_params), 'CreateOctreeWithSuns': CreateOctreeWithSuns(_input_params=self._input_params), 'CreateOctree': CreateOctree(_input_params=self._input_params), 'GenerateSunpath': GenerateSunpath(_input_params=self._input_params), 'CreateTotalSky': CreateTotalSky(_input_params=self._input_params), 'CreateDirectSky': CreateDirectSky(_input_params=self._input_params), 'CreateRadFolder': CreateRadFolder(_input_params=self._input_params), 'SplitGridFolder': SplitGridFolder(_input_params=self._input_params)}
 
     def output(self):
         return {
@@ -174,7 +175,7 @@ class AnnualDaylightRaytracing(luigi.Task):
     _input_params = luigi.DictParameter()
     @property
     def sensor_grids(self):
-        value = pathlib.Path(self.input()['CreateRadFolder']['sensor_grids'].path)
+        value = pathlib.Path(self.input()['SplitGridFolder']['sensor_grids'].path)
         return value.as_posix() if value.is_absolute() \
             else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
 
@@ -185,7 +186,7 @@ class AnnualDaylightRaytracing(luigi.Task):
             return QueenbeeTask.load_input_param(self.sensor_grids)
         except:
             # it is a parameter
-            return pathlib.Path(self.input()['CreateRadFolder']['sensor_grids'].path).as_posix()
+            return pathlib.Path(self.input()['SplitGridFolder']['sensor_grids'].path).as_posix()
 
     def run(self):
         yield [AnnualDaylightRaytracingLoop(item=item, _input_params=self._input_params) for item in self.items]
@@ -206,7 +207,7 @@ class AnnualDaylightRaytracing(luigi.Task):
         return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
 
     def requires(self):
-        return {'CreateSkyDome': CreateSkyDome(_input_params=self._input_params), 'CreateOctreeWithSuns': CreateOctreeWithSuns(_input_params=self._input_params), 'CreateOctree': CreateOctree(_input_params=self._input_params), 'GenerateSunpath': GenerateSunpath(_input_params=self._input_params), 'CreateTotalSky': CreateTotalSky(_input_params=self._input_params), 'CreateDirectSky': CreateDirectSky(_input_params=self._input_params), 'CreateRadFolder': CreateRadFolder(_input_params=self._input_params)}
+        return {'CreateSkyDome': CreateSkyDome(_input_params=self._input_params), 'CreateOctreeWithSuns': CreateOctreeWithSuns(_input_params=self._input_params), 'CreateOctree': CreateOctree(_input_params=self._input_params), 'GenerateSunpath': GenerateSunpath(_input_params=self._input_params), 'CreateTotalSky': CreateTotalSky(_input_params=self._input_params), 'CreateDirectSky': CreateDirectSky(_input_params=self._input_params), 'CreateRadFolder': CreateRadFolder(_input_params=self._input_params), 'SplitGridFolder': SplitGridFolder(_input_params=self._input_params)}
 
     def output(self):
         return {
@@ -258,7 +259,7 @@ class CalculateAnnualMetrics(QueenbeeTask):
         return 'honeybee-radiance post-process annual-daylight raw_results --schedule schedule.txt {thresholds} --sub_folder ../metrics'.format(thresholds=self.thresholds)
 
     def requires(self):
-        return {'ParseSunUpHours': ParseSunUpHours(_input_params=self._input_params), 'AnnualDaylightRaytracing': AnnualDaylightRaytracing(_input_params=self._input_params)}
+        return {'ParseSunUpHours': ParseSunUpHours(_input_params=self._input_params), 'AnnualDaylightRaytracing': AnnualDaylightRaytracing(_input_params=self._input_params), 'RestructureResults': RestructureResults(_input_params=self._input_params)}
 
     def output(self):
         return {
@@ -798,7 +799,157 @@ class ParseSunUpHours(QueenbeeTask):
             }]
 
 
-class _Main_4fe81c3cOrchestrator(luigi.WrapperTask):
+class RestructureResults(QueenbeeTask):
+    """Restructure files in a distributed folder."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def extension(self):
+        return 'ill'
+
+    @property
+    def input_folder(self):
+        value = pathlib.Path('initial_results/final')
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'honeybee-radiance grid merge-folder ./input_folder ./output_folder  {extension}'.format(extension=self.extension)
+
+    def requires(self):
+        return {'AnnualDaylightRaytracing': AnnualDaylightRaytracing(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            'output_folder': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'results').resolve().as_posix()
+            )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'input_folder', 'to': 'input_folder', 'from': self.input_folder, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'output-folder', 'from': 'output_folder',
+                'to': pathlib.Path(self.execution_folder, 'results').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            }]
+
+
+class SplitGridFolder(QueenbeeTask):
+    """Create new sensor grids folder with evenly distributed sensors.
+
+    This function creates a new folder with evenly distributed sensor grids. The folder
+    will include a ``_redist_info.json`` file which has the information to recreate the
+    original input files from this folder and the results generated based on the grids
+    in this folder."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def cpu_count(self):
+        return self._input_params['cpu_count']
+
+    @property
+    def cpus_per_grid(self):
+        return '3'
+
+    @property
+    def min_sensor_count(self):
+        return self._input_params['min_sensor_count']
+
+    @property
+    def input_folder(self):
+        value = pathlib.Path(self.input()['CreateRadFolder']['model_folder'].path, 'grid')
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'honeybee-radiance grid split-folder ./input_folder ./output_folder {cpu_count} --grid-divisor {cpus_per_grid} --min-sensor-count {min_sensor_count}'.format(cpu_count=self.cpu_count, cpus_per_grid=self.cpus_per_grid, min_sensor_count=self.min_sensor_count)
+
+    def requires(self):
+        return {'CreateRadFolder': CreateRadFolder(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            
+            'output_folder': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'resources/grid').resolve().as_posix()
+            ),
+            
+            'dist_info': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'initial_results/final/_redist_info.json').resolve().as_posix()
+            ),
+            'sensor_grids': luigi.LocalTarget(
+                pathlib.Path(
+                    self.params_folder,
+                    'output_folder/_info.json').resolve().as_posix()
+                )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'input_folder', 'to': 'input_folder', 'from': self.input_folder, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'output-folder', 'from': 'output_folder',
+                'to': pathlib.Path(self.execution_folder, 'resources/grid').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            },
+                
+            {
+                'name': 'dist-info', 'from': 'output_folder/_redist_info.json',
+                'to': pathlib.Path(self.execution_folder, 'initial_results/final/_redist_info.json').resolve().as_posix(),
+                'optional': False,
+                'type': 'file'
+            }]
+
+    @property
+    def output_parameters(self):
+        return [{'name': 'sensor-grids', 'from': 'output_folder/_info.json', 'to': pathlib.Path(self.params_folder, 'output_folder/_info.json').resolve().as_posix()}]
+
+
+class _Main_877ed6d8Orchestrator(luigi.WrapperTask):
     """Runs all the tasks in this module."""
     # user input for this module
     _input_params = luigi.DictParameter()

--- a/lbt_recipes/annual_daylight/package.json
+++ b/lbt_recipes/annual_daylight/package.json
@@ -6,7 +6,7 @@
     "type": "MetaData",
     "annotations": {},
     "name": "annual-daylight",
-    "tag": "0.6.5",
+    "tag": "0.6.9",
     "app_version": null,
     "keywords": [
       "honeybee",
@@ -46,17 +46,44 @@
   "source": null,
   "inputs": [
     {
+      "type": "DAGIntegerInput",
+      "annotations": {},
+      "name": "cpu-count",
+      "description": "The maximum number of CPUs for parallel execution. This will be used to determine the number of sensors run by each worker.",
+      "default": 50,
+      "alias": [
+        {
+          "type": "DAGIntegerInputAlias",
+          "annotations": {},
+          "name": "cpu_count",
+          "description": "The maximum number of CPUs for parallel execution. For local simulation, this value is ignored and the cpu_count is automatically set to be equal to the number of workers tasked to the run. For cloud-based runs, this input can be used to control the resources used for the simulation and, if unspecified, the default value of 50 will be used.",
+          "platform": [
+            "grasshopper"
+          ],
+          "handler": [],
+          "default": 50,
+          "required": false,
+          "spec": null
+        }
+      ],
+      "required": false,
+      "spec": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    {
       "type": "DAGStringInput",
       "annotations": {},
       "name": "grid-filter",
-      "description": "Text for a grid identifer or a pattern to filter the sensor grids of the model that are simulated. For instance, first_floor_* will simulate only the sensor grids that have an identifier that starts with first_floor_. By default, all grids in the model will be simulated.",
+      "description": "Text for a grid identifier or a pattern to filter the sensor grids of the model that are simulated. For instance, first_floor_* will simulate only the sensor grids that have an identifier that starts with first_floor_. By default, all grids in the model will be simulated.",
       "default": "*",
       "alias": [
         {
           "type": "DAGStringInputAlias",
           "annotations": {},
           "name": "grid_filter",
-          "description": "Text for a grid identifer or a pattern to filter the sensor grids of the model that are simulated. For instance, first_floor_* will simulate only the sensor grids that have an identifier that starts with first_floor_. By default, all grids in the model will be simulated.",
+          "description": "Text for a grid identifier or a pattern to filter the sensor grids of the model that are simulated. For instance, first_floor_* will simulate only the sensor grids that have an identifier that starts with first_floor_. By default, all grids in the model will be simulated.",
           "platform": [
             "grasshopper"
           ],
@@ -68,6 +95,33 @@
       ],
       "required": false,
       "spec": null
+    },
+    {
+      "type": "DAGIntegerInput",
+      "annotations": {},
+      "name": "min-sensor-count",
+      "description": "The minimum number of sensors in each sensor grid after redistributing the sensors based on cpu_count. This value takes precedence over the cpu_count and can be used to ensure that the parallelization does not result in generating unnecessarily small sensor grids. The default value is set to 1, which means that the cpu_count is always respected.",
+      "default": 1,
+      "alias": [
+        {
+          "type": "DAGIntegerInputAlias",
+          "annotations": {},
+          "name": "min_sen_count",
+          "description": "Positive integer for the minimum number of sensors in each grid after redistributing the sensors based on cpu_count. This value takes precedence over the cpu_count and can be used to ensure that the parallelization does not result in generating unnecessarily small sensor grids that increase overhead. (Default: 200).",
+          "platform": [
+            "grasshopper"
+          ],
+          "handler": [],
+          "default": 200,
+          "required": false,
+          "spec": null
+        }
+      ],
+      "required": false,
+      "spec": {
+        "type": "integer",
+        "minimum": 1
+      }
     },
     {
       "type": "DAGFileInput",
@@ -233,33 +287,6 @@
         "txt",
         "csv"
       ]
-    },
-    {
-      "type": "DAGIntegerInput",
-      "annotations": {},
-      "name": "sensor-count",
-      "description": "The maximum number of grid points per parallel execution.",
-      "default": 200,
-      "alias": [
-        {
-          "type": "DAGIntegerInputAlias",
-          "annotations": {},
-          "name": "sensor_count",
-          "description": "Positive integer for the number of sensor grid points per parallel execution. Lower numbers will result in sensor grids being split into more pieces and, since each grid piece is run by a separate worker, this can mean a faster simulation on machines with several CPUs. However ,If the number is too low, the overhad of splitting the grid will not be worth the time gained through parallelization. (Default: 200).",
-          "platform": [
-            "grasshopper"
-          ],
-          "handler": [],
-          "default": 200,
-          "required": false,
-          "spec": null
-        }
-      ],
-      "required": false,
-      "spec": {
-        "type": "integer",
-        "minimum": 1
-      }
     },
     {
       "type": "DAGStringInput",

--- a/lbt_recipes/annual_daylight/run.py
+++ b/lbt_recipes/annual_daylight/run.py
@@ -23,12 +23,13 @@ from queenbee_local import local_scheduler, _copy_artifacts, update_params, pars
 import flow.main as annual_daylight_workerbee
 
 
-_recipe_default_inputs = {   'grid_filter': '*',
+_recipe_default_inputs = {   'cpu_count': 50,
+    'grid_filter': '*',
+    'min_sensor_count': 1,
     'model': None,
     'north': 0.0,
     'radiance_parameters': '-ab 2 -ad 5000 -lw 2e-05',
     'schedule': None,
-    'sensor_count': 200,
     'thresholds': '-t 300 -lt 100 -ut 3000',
     'wea': None}
 
@@ -38,7 +39,7 @@ class LetAnnualDaylightFly(luigi.WrapperTask):
     _input_params = luigi.DictParameter()
 
     def requires(self):
-        yield [annual_daylight_workerbee._Main_4fe81c3cOrchestrator(_input_params=self._input_params)]
+        yield [annual_daylight_workerbee._Main_877ed6d8Orchestrator(_input_params=self._input_params)]
 
 
 def start(project_folder, user_values, workers):


### PR DESCRIPTION
This fix aligns the grid-splitting behavior with the workers that are specified for the luigi recipe. It ensures that the recipe is always run in the most efficient way possible for the number of workers - no more grids are generated than can be handled by the number of processors.